### PR TITLE
feat: add kms key arn input for customer-managed keys

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -8,7 +8,7 @@ locals {
   ssm_path_prefix         = format("/%s/%s", var.ssm_path_prefix, module.aurora_postgres.outputs.cluster_identifier)
   ssm_password_source     = length(var.ssm_password_source) > 0 ? var.ssm_password_source : format("%s/%s", local.ssm_path_prefix, "%s/password")
 
-  kms_key_arn = module.aurora_postgres.outputs.kms_key_arn
+  kms_key_arn = coalesce(module.aurora_postgres.outputs.kms_key_arn, var.kms_key_arn)
 
   default_schema_owner = "postgres"
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -47,6 +47,12 @@ variable "cluster_enabled" {
   description = "Set to `false` to prevent the module from creating any resources"
 }
 
+variable "kms_key_arn" {
+  type        = string
+  description = "The ARN for the KMS encryption key."
+  default     = null
+}
+
 variable "additional_databases" {
   type        = set(string)
   default     = []


### PR DESCRIPTION
## why

- This PR introduces a new `kms_key_arn` variable, allowing consumers to supply their own customer-managed KMS key

## what

1. **Default behavior**  
   - Deploy without setting `kms_key_arn`  
   - Module-created CMK is used for both RDS and SSM

2. **Override behavior**  
   - Deploy with `kms_key_arn = "arn:aws:kms:…:key/EXAMPLE"`  
   - Verify that both the RDS cluster and SSM parameter use the supplied ARN

## references

- Resolves [this discussion](https://github.com/orgs/cloudposse/discussions/30)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a custom KMS encryption key ARN through a new configuration variable.
  - Improved flexibility by allowing fallback to a user-provided KMS key ARN if the default is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->