### PR TITLE
Allow setting roles for users

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -41,6 +41,7 @@ module "additional_users" {
   service_name    = each.key
   db_user         = each.value.db_user
   db_password     = each.value.db_password
+  roles           = each.value.roles
   grants          = each.value.grants
   ssm_path_prefix = local.ssm_path_prefix
   kms_key_id      = local.kms_key_arn

--- a/src/modules/postgresql-user/main.tf
+++ b/src/modules/postgresql-user/main.tf
@@ -1,9 +1,9 @@
 locals {
   enabled = module.this.enabled
 
-  db_user     = length(var.db_user) > 0 ? var.db_user : var.service_name
-  db_password = length(var.db_password) > 0 ? var.db_password : join("", random_password.db_password[*].result)
-
+  db_user              = length(var.db_user) > 0 ? var.db_user : var.service_name
+  db_password          = length(var.db_password) > 0 ? var.db_password : join("", random_password.db_password[*].result)
+  db_roles             = try(length(var.roles) > 0 ? var.roles : null, null)
   save_password_in_ssm = local.enabled && var.save_password_in_ssm
 
   db_password_key = format("%s/%s/passwords/%s", var.ssm_path_prefix, var.service_name, local.db_user)
@@ -14,6 +14,7 @@ locals {
     type        = "SecureString"
     overwrite   = true
   } : null
+
 
   parameter_write = local.save_password_in_ssm ? [local.db_password_ssm] : []
 
@@ -40,6 +41,7 @@ resource "postgresql_role" "default" {
   name     = local.db_user
   password = local.db_password
   login    = true
+  roles    = local.db_roles
 }
 
 # Apply the configured grants to the user

--- a/src/modules/postgresql-user/variables.tf
+++ b/src/modules/postgresql-user/variables.tf
@@ -15,6 +15,12 @@ variable "db_password" {
   default     = ""
 }
 
+variable "roles" {
+  type        = list(string)
+  description = "Roles that will be granted to the created user."
+  default     = null
+}
+
 variable "grants" {
   type = list(object({
     grant : list(string)

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -64,6 +64,7 @@ variable "additional_users" {
   type = map(object({
     db_user : string
     db_password : string
+    roles : optional(list(string), [])
     grants : list(object({
       grant : list(string)
       db : string


### PR DESCRIPTION
## what
* Add the roles parameter so database roles can be granted/assigned to users that are created by the postgres plugin.

## why
* In this case this allows me to grant the `rds_superuser` role to a newly created user to manage extensions. 

## references
* https://registry.terraform.io/providers/cyrilgdn/postgresql/latest/docs/resources/postgresql_role.html#roles-1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assign PostgreSQL roles to created users via an optional roles list for additional users, granting membership at creation.
  * Role assignment is integrated into user creation while preserving existing grants and password handling.
  * Backward-compatible: omitting roles leaves prior behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->