### PR TITLE
Update engine version date in aurora-postgres.yaml

### DIFF
--- a/test/fixtures/stacks/catalog/aurora-postgres.yaml
+++ b/test/fixtures/stacks/catalog/aurora-postgres.yaml
@@ -20,7 +20,7 @@ components:
         # Serverless v2 configuration
         engine_mode: provisioned
         instance_type: "db.serverless" # serverless engine_mode ignores `var.instance_type`
-        engine_version: "13.22" # Latest supported version as of 10/08/2025
+        engine_version: "13.21" # Latest supported version as of 10/08/2025
         cluster_family: aurora-postgresql13
         cluster_size: 1
          # serverless

--- a/test/fixtures/stacks/catalog/aurora-postgres.yaml
+++ b/test/fixtures/stacks/catalog/aurora-postgres.yaml
@@ -20,7 +20,7 @@ components:
         # Serverless v2 configuration
         engine_mode: provisioned
         instance_type: "db.serverless" # serverless engine_mode ignores `var.instance_type`
-        engine_version: "13.22" # Latest supported version as of 08/28/2023
+        engine_version: "13.22" # Latest supported version as of 10/08/2025
         cluster_family: aurora-postgresql13
         cluster_size: 1
          # serverless


### PR DESCRIPTION
## what
* Update engine version date in aurora-postgres.yaml

## why
* `13.12` is EOL on AWS

## references
* https://linear.app/cloudposse/issue/DEV-3640/decommission-aurora-postgresql-cluster-in-sandbox-aws-799847381734-us

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comments to clarify the Aurora PostgreSQL engine version, refreshing the “latest supported version” date to 10/08/2025 for accuracy.
  * No functional, configuration, or behavioral changes; existing engine_version remains unchanged.
  * Improves clarity for users reviewing stack configurations and planning upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->