### PR TITLE
feat: add support for role memberships

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -68,7 +68,13 @@ usage: |-
                   db: example
                   object_type: database
                   schema: ""
+            role_memberships:
+              - reporting_reader
+              - reporting_writer
   ```
+
+  Use the optional `role_memberships` list inside an `additional_users` entry to grant existing database roles to the user managed by this module.
+
 references:
   - name: "cloudposse-terraform-components"
     description: "Cloud Posse's upstream component"

--- a/src/README.md
+++ b/src/README.md
@@ -73,8 +73,12 @@ components:
                 db: example
                 object_type: database
                 schema: ""
+            role_memberships:
+              - reporting_reader
+              - reporting_writer
 ```
 
+Use the optional `role_memberships` list inside an `additional_users` entry to grant existing database roles to the user managed by this module.
 
 <!-- markdownlint-disable -->
 ## Requirements

--- a/src/README.md
+++ b/src/README.md
@@ -73,12 +73,7 @@ components:
                 db: example
                 object_type: database
                 schema: ""
-            role_memberships:
-              - reporting_reader
-              - reporting_writer
 ```
-
-Use the optional `role_memberships` list inside an `additional_users` entry to grant existing database roles to the user managed by this module.
 
 <!-- markdownlint-disable -->
 ## Requirements

--- a/src/main.tf
+++ b/src/main.tf
@@ -38,12 +38,13 @@ module "additional_users" {
   for_each = local.enabled ? var.additional_users : {}
   source   = "./modules/postgresql-user"
 
-  service_name    = each.key
-  db_user         = each.value.db_user
-  db_password     = each.value.db_password
-  grants          = each.value.grants
-  ssm_path_prefix = local.ssm_path_prefix
-  kms_key_id      = local.kms_key_arn
+  service_name     = each.key
+  db_user          = each.value.db_user
+  db_password      = each.value.db_password
+  grants           = each.value.grants
+  role_memberships = try(each.value.role_memberships, [])
+  ssm_path_prefix  = local.ssm_path_prefix
+  kms_key_id       = local.kms_key_arn
 
   depends_on = [
     postgresql_database.additional,

--- a/src/modules/postgresql-user/variables.tf
+++ b/src/modules/postgresql-user/variables.tf
@@ -28,6 +28,12 @@ variable "grants" {
   default     = [{ grant : ["ALL"], db : "*", schema : "", object_type : "database" }]
 }
 
+variable "role_memberships" {
+  type        = list(string)
+  default     = []
+  description = "List of roles to grant membership in for the user created by this module."
+}
+
 variable "ssm_path_prefix" {
   type        = string
   default     = "aurora-postgres"

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -70,6 +70,7 @@ variable "additional_users" {
       schema : string
       object_type : string
     }))
+    role_memberships : optional(list(string), [])
   }))
   default     = {}
   description = <<-EOT


### PR DESCRIPTION
## what
* Added support for role memberships

## why
* This allows a user to be assigned to a role instead of duplicating grants

## references


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now grant existing database roles to managed users via an optional per-user "role_memberships" setting.

* **Documentation**
  * Usage examples and docs updated to show how to specify role memberships (e.g., reporting_reader, reporting_writer) for managed users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->