### PR TITLE
Support default privileges

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -71,9 +71,16 @@ usage: |-
             role_memberships:
               - reporting_reader
               - reporting_writer
+            default_privileges:
+              - role: another_role
+                privileges: ["SELECT", "INSERT", "UPDATE", "DELETE"]
+                db: example
+                object_type: table
+                schema: ""
   ```
 
   Use the optional `role_memberships` list inside an `additional_users` entry to grant existing database roles to the user managed by this module.
+  Use the optional `default_privileges` list inside an `additional_users` entry to grant default privileges to the specified role. Whenever the user managed by this module creates a new object of the specified type in the specified schema, the specified role will be automatically granted the specified privileges.
 
 references:
   - name: "cloudposse-terraform-components"

--- a/src/main.tf
+++ b/src/main.tf
@@ -38,13 +38,14 @@ module "additional_users" {
   for_each = local.enabled ? var.additional_users : {}
   source   = "./modules/postgresql-user"
 
-  service_name     = each.key
-  db_user          = each.value.db_user
-  db_password      = each.value.db_password
-  grants           = each.value.grants
-  role_memberships = try(each.value.role_memberships, [])
-  ssm_path_prefix  = local.ssm_path_prefix
-  kms_key_id       = local.kms_key_arn
+  service_name       = each.key
+  db_user            = each.value.db_user
+  db_password        = each.value.db_password
+  grants             = each.value.grants
+  default_privileges = each.value.default_privileges
+  role_memberships   = try(each.value.role_memberships, [])
+  ssm_path_prefix    = local.ssm_path_prefix
+  kms_key_id         = local.kms_key_arn
 
   depends_on = [
     postgresql_database.additional,

--- a/src/modules/postgresql-user/variables.tf
+++ b/src/modules/postgresql-user/variables.tf
@@ -23,9 +23,24 @@ variable "grants" {
     object_type : string
   }))
   description = <<-EOT
-    List of { grant: [<grant>, <grant>, ...], db: "db", schema: "", object_type: "database"}.
+    List of { grant: [<grant>, <grant>, ...], db: "db", schema: "", object_type: "database" }.
     EOT
   default     = [{ grant : ["ALL"], db : "*", schema : "", object_type : "database" }]
+}
+
+variable "default_privileges" {
+  type = list(object({
+    role : string
+    privileges : list(string)
+    db : string
+    schema : optional(string, "")
+    object_type : string
+  }))
+  description = <<-EOT
+  List of { role: "", privileges: [<grant>, <grant>, ...], db: "db", schema: "", object_type: "table" }
+  Role refers to the target database role (user) that will be automatically granted the specified privileges when the created by this module creates the specified objects.
+  EOT
+  default     = []
 }
 
 variable "role_memberships" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -70,11 +70,18 @@ variable "additional_users" {
       schema : string
       object_type : string
     }))
+    default_privileges : optional(list(object({
+      role : string
+      privileges : list(string)
+      db : string
+      schema : string
+      object_type : string
+    })), [])
     role_memberships : optional(list(string), [])
   }))
   default     = {}
   description = <<-EOT
-    Create additional database user for a service, specifying username, grants, and optional password.
+    Create additional database user for a service, specifying username, (default) grants, and optional password.
     If no password is specified, one will be generated. Username and password will be stored in
     SSM parameter store under the service's key.
     EOT


### PR DESCRIPTION
## what
- This change will allow automatically granting privileges to other roles/users when the user creates an object.

## why
- This allows granting permissions automatically to the specified role whenever the user creates the specified objects in the specified schema - e.g. 

```sql
ALTER DEFAULT PRIVILEGES IN SCHEMA public FOR ROLE example GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO another_role;
``` 

## references
- https://registry.terraform.io/providers/cyrilgdn/postgresql/latest/docs/resources/postgresql_default_privileges


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring default privileges on database objects. Users can now specify automatic privilege grants for database roles on newly created objects by setting role, privileges, database, schema, and object type parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->