### PR TITLE
Make role membership stable by removing additional postgresql_grant_role resource

### DIFF
--- a/src/modules/postgresql-user/main.tf
+++ b/src/modules/postgresql-user/main.tf
@@ -40,6 +40,7 @@ resource "postgresql_role" "default" {
   name     = local.db_user
   password = local.db_password
   login    = true
+  roles    = var.role_memberships
 }
 
 # Apply the configured grants to the user

--- a/src/modules/postgresql-user/main.tf
+++ b/src/modules/postgresql-user/main.tf
@@ -23,12 +23,6 @@ locals {
   # https://github.com/cyrilgdn/terraform-provider-postgresql/blob/master/postgresql/helpers.go#L237-L244
   all_privileges_database = ["CREATE", "CONNECT", "TEMPORARY"]
   all_privileges_schema   = ["CREATE", "USAGE"]
-  role_membership_pairs = local.enabled ? [
-    for grant_role in var.role_memberships : {
-      role       = local.db_user
-      grant_role = grant_role
-    }
-  ] : []
 }
 
 resource "random_password" "db_password" {
@@ -60,15 +54,6 @@ resource "postgresql_grant" "default" {
   # or schema privileges if this is a db grant or a schema grant respectively.
   # We can determine this is a schema grant if a schema is given
   privileges = contains(var.grants[count.index].grant, "ALL") ? ((length(var.grants[count.index].schema) > 0) ? local.all_privileges_schema : local.all_privileges_database) : var.grants[count.index].grant
-}
-
-resource "postgresql_grant_role" "role_memberships" {
-  for_each = { for membership in local.role_membership_pairs : "${membership.role}:${membership.grant_role}" => membership }
-
-  role       = each.value.role
-  grant_role = each.value.grant_role
-
-  depends_on = [postgresql_role.default]
 }
 
 module "parameter_store_write" {


### PR DESCRIPTION
## what
* Remove `postgresql_grant_role.role_memberships` resource.
* Set roles on `postgreql_role.default` instead. 

## why
* `postgresql_role.default` and `postgresql_grant_role.role_memberships` are conflicting. The first attempts to add roles, the latter to remove roles.
* Can't do without `postgresql_role.default` since this resource creates the role, so use that to set the roles. This accomplishes the same as `postgresql_grant_role.role_memberships` was doing.

## references
* Closes #55 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined role membership assignment in the PostgreSQL user module for improved maintainability and reduced complexity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->