### PR TITLE
fix: prevent infinite plan loop for role_memberships (#55)

### DIFF
--- a/src/modules/postgresql-user/main.tf
+++ b/src/modules/postgresql-user/main.tf
@@ -46,6 +46,12 @@ resource "postgresql_role" "default" {
   name     = local.db_user
   password = local.db_password
   login    = true
+
+  # Ignore role memberships managed by postgresql_grant_role to prevent
+  # infinite plan loop (#55)
+  lifecycle {
+    ignore_changes = [roles]
+  }
 }
 
 # Apply the configured grants to the user

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -14,6 +14,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = "../account-map/modules/iam-roles"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=v1.537.2"
   context = module.this.context
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "aurora_postgres" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component = var.aurora_postgres_component_name
 

--- a/test/fixtures/stacks/catalog/aurora-postgres.yaml
+++ b/test/fixtures/stacks/catalog/aurora-postgres.yaml
@@ -20,8 +20,8 @@ components:
         # Serverless v2 configuration
         engine_mode: provisioned
         instance_type: "db.serverless" # serverless engine_mode ignores `var.instance_type`
-        engine_version: "13.21" # Latest supported version as of 10/08/2025
-        cluster_family: aurora-postgresql13
+        engine_version: "16.13"
+        cluster_family: aurora-postgresql16
         cluster_size: 1
          # serverless
         serverlessv2_scaling_configuration:


### PR DESCRIPTION
## What

Add `lifecycle { ignore_changes = [roles] }` to `postgresql_role.default` in the `postgresql-user` submodule.

## Why

The `postgresql_role` resource's `roles` attribute conflicts with `postgresql_grant_role` — both try to manage role memberships, causing an add/remove loop on every `plan`/`apply` that never converges (as described in #55).

With `ignore_changes = [roles]`, `postgresql_role` only manages the role itself (name, password, login) while `postgresql_grant_role` exclusively owns membership state. This preserves the granular per-membership tracking introduced in #48 while eliminating the drift.

## Alternative to PR #58

PR #58 takes the opposite approach: removing `postgresql_grant_role` entirely and using `roles` directly on `postgresql_role`. While simpler, that approach:

- Loses per-membership state tracking (`postgresql_grant_role` creates a separate resource per membership with a stable key)
- May still show drift if the provider returns `roles` in a different order than configured
- Undoes the work from #48 which intentionally introduced `postgresql_grant_role` for better granularity

The `ignore_changes` approach is the standard Terraform pattern for resolving this kind of dual-ownership conflict and preserves the architecture from #48.

## Testing

Tested in production against Aurora PostgreSQL 17.9 with multiple users having `role_memberships: [rds_iam]`. After applying the fix, `terraform plan` shows no changes on subsequent runs — the infinite loop is resolved.

## References

- Closes #55
- Alternative to #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * PostgreSQL role membership will no longer be automatically reconciled, allowing manual role membership management.
  * IAM role provisioning now uses a specific remote release to standardize module sourcing.
  * Remote-state module version bumped to a newer release for updated remote state handling.
  * Aurora PostgreSQL fixture updated to engine version 16 and matching cluster family.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->